### PR TITLE
Add agave rinkeby subgraph configurations

### DIFF
--- a/config/rinkeby.json
+++ b/config/rinkeby.json
@@ -1,0 +1,13 @@
+{
+  "network": "rinkeby",
+  "AaveOracleAddress": "0x3aD3B127f890623085691F740eD021A665f6648F",
+  "AaveOracleStartBlock": 8120417,
+  "ChainlinkSourcesRegistryAddress": "0x05ccebD43Dcf66BE1BC83aCe122a04658B4c9811",
+  "ChainlinkSourcesRegistryStartBlock": 8121696,
+  "LendingPoolAddressesProviderRegistryAddress": "0x33c99beB183107f008D74cF0Fa2B5108AF5fD4A1",
+  "LendingPoolAddressesProviderRegistryStartBlock": 8120393,
+  "UniswapLiquiditySwapAdapterAddress": "0x007aeCE602455d0b4b694B448FE751301127ba67",
+  "UniswapLiquiditySwapAdapterStartBlock": 8121587,
+  "UniswapRepayAdapterAddress": "0x4dF5b0126b658B893A60B871C44ac9c84e45f110",
+  "UniswapRepayAdapterStartBlock": 8121582
+}

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "deploy-stack:local:scenario": "npm run submodule:deploy:scenario && npm run update-abi-addresses && npm run prepare:subgraph && npm run subgraph:local",
     "deploy-stack:local:post-scenario": "npm run update-abi-addresses && npm run prepare:subgraph && npm run subgraph:deploy:local",
     "deploy:hosted:kovan": "NETWORK=kovan env-cmd npm run prepare:subgraph && SLUG=aave/protocol-v2-kovan env-cmd npm run subgraph:deploy:hosted",
+    "deploy:hosted:rinkeby": "NETWORK=rinkeby env-cmd npm run prepare:subgraph && SLUG=1hive/agave-rinkeby env-cmd npm run subgraph:deploy:hosted",
     "deploy:hosted:mainnet": "NETWORK=mainnet env-cmd npm run prepare:subgraph && SLUG=aave/protocol-v2 env-cmd npm run subgraph:deploy:hosted",
     "deploy:self-hosted:kovan": "NETWORK=kovan npm run prepare:subgraph && SLUG=aave/protocol-v2-kovan npm run subgraph:deploy:self-hosted",
     "deploy:self-hosted:mainnet": "NETWORK=mainnet npm run prepare:subgraph && SLUG=aave/protocol-v2 npm run subgraph:deploy:self-hosted"


### PR DESCRIPTION
Here is a gist with the whole rinkeby deployment: https://gist.github.com/0xGabi/430941d645b50a64c3e78f4c28c7843d

The `Adapters` and `ChainlinkSourcesRegistry` were manually deployed.